### PR TITLE
Fix require import syntax

### DIFF
--- a/lib/meteor/meteor.js
+++ b/lib/meteor/meteor.js
@@ -1,4 +1,4 @@
-const { Mongo } = require('./mongo');
+const mongo = require('./mongo');
 
 const Meteor = {
   isServer: true,
@@ -9,7 +9,7 @@ const Meteor = {
   publish: jest.fn(),
   subscribe: jest.fn(),
   user: jest.fn(),
-  users: new Mongo.Collection(),
+  users: new mongo.Mongo.Collection(),
   userId: jest.fn().mockReturnValue('f00bar'),
   startup: jest.fn(),
   bindEnvironment: jest.fn(),


### PR DESCRIPTION
Hello!
Ran in to a problem where I got 
```
SyntaxError: Unexpected token {
```
Which I believe is due to the fact that named imports only became supported with the new import/export syntax, and not require. The following changes seemed to work for me.

Thanks!